### PR TITLE
Fixed partially typed input bug

### DIFF
--- a/nodriver/core/element.py
+++ b/nodriver/core/element.py
@@ -603,10 +603,10 @@ class Element:
         :return: None
         """
         await self.apply("(elem) => elem.focus()")
-        [
+
+        for char in text:
             await self._tab.send(cdp.input_.dispatch_key_event("char", text=char))
-            for char in list(text)
-        ]
+            await asyncio.sleep(0.02
 
     async def send_file(self, *file_paths: PathLike):
         """


### PR DESCRIPTION
Added a sleep that solves an issue with the send_keys() method failing to write the whole string provided. It was usually caused from medium length strings (around 12+ chars).